### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,5 +57,5 @@ Usage
 
 .. |Build| image:: https://api.travis-ci.org/mozillazg/bild.me-cli.png?branch=master
    :target: https://travis-ci.org/mozillazg/bild.me-cli
-.. |PyPI version| image:: https://pypip.in/v/bild.me-cli/badge.png
+.. |PyPI version| image:: https://img.shields.io/pypi/v/bild.me-cli.svg
    :target: https://crate.io/packages/bild.me-cli


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20bild-me-cli))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `bild-me-cli`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.